### PR TITLE
Cloudwatch object now updates on auth update

### DIFF
--- a/opkit.js
+++ b/opkit.js
@@ -9,25 +9,30 @@ A framework to help you build devops bots
 
 var Botkit = require('botkit');
 var AWS = require('aws-sdk');
+var cloudwatch = new AWS.CloudWatch({apiVersion: '2016-05-12'});
 
 //Functions that allow you to update the authorization keys (both at a time or each at once)
+//Each update also recreates the singleton object cloudwatch
 function updateAuthKeys(accessKeyId, secretAccessKey){
     AWS.config.update({
         accessKeyId: accessKeyId, 
         secretAccessKey: secretAccessKey
     });
+    cloudwatch = new AWS.CloudWatch({apiVersion: '2016-05-12'})
 }
 
 function updateAccessKeyId(accessKeyId){
     AWS.config.update({
         accessKeyId: accessKeyId
     });
+    cloudwatch = new AWS.CloudWatch({apiVersion: '2016-05-12'})
 }
 
 function updateSecretAccessKey(secretAccessKey){
     AWS.config.update({
         secretAccessKey: secretAccessKey
     });
+    cloudwatch = new AWS.CloudWatch({apiVersion: '2016-05-12'})
 }
 
 //Functions that allow you to update the AWS region from which you are querying
@@ -35,4 +40,5 @@ function updateRegion(targetRegion){
     AWS.config.update({
         region: targetRegion
     });
+    cloudwatch = new AWS.CloudWatch({apiVersion: '2016-05-12'})
 }


### PR DESCRIPTION
Old version did not update the cloudwatch object when user updated auth. Now, this makes sure that whenever a query is placed, it uses the newest and most relevant auth info. :D
