### PR TITLE
Added way to set a shortName

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -46,7 +46,6 @@ Auth.prototype.updateRegion = function(targetRegion){
    Function: shortName
    Updates this.shortName to enable database queries/key-value stores indexed
    by some name.
-
 */
 
 Auth.prototype.updateShortName = function(name){


### PR DESCRIPTION
You can now name your auths (say, as "development" or "production".)
