### PR TITLE
Bot now sends "access denied"

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -50,6 +50,8 @@ function OpkitBot(name, commands, state) {
 					});
 				})
 				.catch(function(err){
+					self.sendMessage("Access denied." +
+					"See administrator if you feel you should have access.", message.channel);
 					winston.log('warn', err);
 				});
 			}


### PR DESCRIPTION
If the authorization fails, the bot now sends a sufficiently descriptive error message.
