### PR TITLE
Cleaning up tests written awhile ago

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/inetCatapult/opkit#readme",
   "devDependencies": {
-    "aws-sdk-mock": "^1.1.0",
     "chai": "^3.5.0",
     "fs-extra": "^0.30.0",
     "fs-extra-promise": "^0.4.0",

--- a/test/ec2-test.js
+++ b/test/ec2-test.js
@@ -2,7 +2,7 @@ var assert = require('chai').assert;
 var opkit = require('../index');
 var ecInstance = new opkit.EC2();
 var sinon = require('sinon');
-var AWSMock = require('aws-sdk-mock');
+require('sinon-as-promised');
 var AWS = require('aws-promised');
 
 describe('EC2', function() {
@@ -16,29 +16,22 @@ describe('EC2', function() {
 		auth1.updateRegion('narnia-1');
 		auth1.updateAuthKeys('shiny gold one', 'old rusty one');
 
-		AWSMock.mock('EC2', 'startInstances', function(params, callback) {
-			var data = 2;
-			callback(null, data);
-		});
-
-		AWSMock.mock('EC2', 'stopInstances', function(params, callback) {
-			var data = 9;
-			callback(null, data);
-		});
-
-		AWSMock.mock('EC2', 'describeInstances', function(params, callback) {
-			var data = {};
-			data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
-									Tags : [{Key : 'Name', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
-			callback(null, data);
-		});
-
-		AWSMock.mock('EC2', 'waitFor', function(string, params, callback) {
-			callback(null, "Success");
-		});
-
-		AWSMock.mock('EC2', 'getConsoleOutput', function(params, callback) {
-			callback(null, {Timestamp : 1, Output : 'dGVzdA=='});
+		sinon.stub(AWS, 'ec2', function(auth) {
+			this.startInstancesPromised = function(params) {
+				return Promise.resolve(true);
+			};
+			this.stopInstancesPromised = function(params) {
+				return Promise.resolve(true);
+			};
+			this.describeInstancesPromised = function(params) {
+				var data = {};
+				data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
+										Tags : [{Key : 'Name', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
+				return Promise.resolve(data);
+			};
+			this.waitForPromised = function(params) {
+				return Promise.resolve("Success");
+			};
 		});
 	});
 
@@ -47,201 +40,264 @@ describe('EC2', function() {
 		spy = undefined;
 	});
 
-	describe("start", function() {
-		before(function() {
-			return ecInstance.start('Name', 'My-EC2', auth1)
-			.then(function(data) {
-				result = data;
-			});			
-		});
-
-		it("starting an EC2 instance works", function() {
-			assert.equal(result, "Success");
-		});
+	after(function() {
+		AWS.ec2.restore();
 	});
 
-	describe("startByName", function() {
-		before(function() {
-			spy = sinon.spy(ecInstance, "start");
-			return ecInstance.startByName('My-EC2', auth1)
-			.then(function(data) {
-				result = data;
-			});			
-		});
+	describe("starting and stopping instaces", function() {
+		describe("start", function() {
+			before(function() {
+				return ecInstance.start('Name', 'My-EC2', auth1)
+				.then(function(data) {
+					result = data;
+				});			
+			});
 
-		it("starting an EC2 instance by name works", function() {
-			assert.equal(spy.calledWithExactly('Name', 'My-EC2', auth1),true);			
-		});
-	});
-
-	describe("stop", function() {
-		before(function() {
-			return ecInstance.stop('Name', 'My-EC2', auth1)
-			.then(function(data) {
-				result = data;
+			it("starting an EC2 instance works", function() {
+				assert.equal(result, "Success");
 			});
 		});
 
-		it("stopping an EC2 instance works", function() {
-			assert.equal(result, "Success");
-		});
-	});
+		describe("startByName", function() {
+			before(function() {
+				spy = sinon.spy(ecInstance, "start");
+				return ecInstance.startByName('My-EC2', auth1)
+				.then(function(data) {
+					result = data;
+				});			
+			});
 
-	describe("stopByName", function() {
-		before(function() {
-			spy = sinon.spy(ecInstance, 'stop');
-			return ecInstance.stopByName('My-EC2', auth1)
-			.then(function(data) {
-				result = data;
-			});			
-		});
-
-		it("stopping an EC2 instance by name works", function() {
-			assert.equal(spy.calledWithExactly('Name', 'My-EC2', auth1),true);
-		});
-	});
-
-	describe("getInstanceID", function() {
-		before(function() {
-			return ecInstance.getInstanceID('tag', 'My-EC2', auth1)
-			.then(function(data) {
-				result = data;
+			it("starting an EC2 instance by name works", function() {
+				assert.equal(spy.calledWithExactly('Name', 'My-EC2', auth1),true);			
 			});
 		});
 
-		it("getting the instance ID of a specified EC2 instance works", function() {
-			assert.equal(result[0], 'ExampleId');
+		describe("stop", function() {
+			before(function() {
+				return ecInstance.stop('Name', 'My-EC2', auth1)
+				.then(function(data) {
+					result = data;
+				});
+			});
+
+			it("stopping an EC2 instance works", function() {
+				assert.equal(result, "Success");
+			});
+		});
+
+		describe("stopByName", function() {
+			before(function() {
+				spy = sinon.spy(ecInstance, 'stop');
+				return ecInstance.stopByName('My-EC2', auth1)
+				.then(function(data) {
+					result = data;
+				});			
+			});
+
+			it("stopping an EC2 instance by name works", function() {
+				assert.equal(spy.calledWithExactly('Name', 'My-EC2', auth1),true);
+			});
 		});
 	});
 
-	describe("listInstances", function() {
-		before(function() {
-			return ecInstance.listInstances('tag', 'My-EC2', auth1)
-			.then(function(data) {
-				result = data;
+	describe('Identifying EC2 instances', function() {
+		describe("getInstanceID", function() {
+			before(function() {
+				AWS.ec2.restore();
+				sinon.stub(AWS, 'ec2', function(auth) {
+					this.describeInstancesPromised = function(params) {
+						var data = {};
+						data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
+												Tags : [{Key : 'Name', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
+						return Promise.resolve(data);
+					};
+				});
+				return ecInstance.getInstanceID('tag', 'My-EC2', auth1)
+				.then(function(data) {
+					result = data;
+				});
+			});
+
+			it("getting the instance ID of a specified EC2 instance works", function() {
+				assert.equal(result[0], 'ExampleId');
 			});
 		});
 
-		it("listing instances works", function() {
-			assert.equal(JSON.stringify(result[0]), 
-							'{"Name":"Tag","State":"Testing","id":"ExampleId"}');
+		describe("listInstances", function() {
+			before(function() {
+				return ecInstance.listInstances('tag', 'My-EC2', auth1)
+				.then(function(data) {
+					result = data;
+				});
+			});
+
+			it("listing instances works", function() {
+				assert.equal(JSON.stringify(result[0]), 
+								'{"Name":"Tag","State":"Testing","id":"ExampleId"}');
+			});
+		});
+
+		describe("listInstances without a name tag", function() {
+			before(function() {
+				AWS.ec2.restore();
+				sinon.stub(AWS, 'ec2', function(auth) {
+					this.describeInstancesPromised = function(params) {
+						var data = {};
+						data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
+												Tags : [{Key : 'NotName', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
+						return Promise.resolve(data);
+					};
+				});
+				return ecInstance.listInstances('tag', 'My-EC2', auth1)
+				.then(function(data) {
+					result = data;
+				});
+			});
+
+			it("listing instances without a name tag works", function() {
+				assert.equal(JSON.stringify(result[0]), 
+								'{"State":"Testing","id":"ExampleId"}');
+			});
 		});
 	});
 
-	describe("listInstances without a name tag", function() {
-		before(function() {
-			AWSMock.restore('EC2', 'describeInstances');
-			AWSMock.mock('EC2', 'describeInstances', function(params, callback) {
-				var data = {};
-				data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
-										Tags : [{Key : 'NotName', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
-				callback(null, data);
+	describe('Identifying instances by status', function() {
+		describe("getInstancesStatus", function() {
+			before(function() {
+				AWS.ec2.restore();
+				sinon.stub(AWS, 'ec2', function(auth) {
+					this.describeInstancesPromised = function(params) {
+						var data = {};
+						data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
+												Tags : [{Key : 'NotName', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
+						return Promise.resolve(data);
+					};
+				});
+				return ecInstance.getInstancesStatus('tag', 'My-EC2', 'running', auth1)
+				.then(function(data) {
+					result = data;
+				});
 			});
-			return ecInstance.listInstances('tag', 'My-EC2', auth1)
-			.then(function(data) {
-				result = data;
+
+			it("getting data about instances based on state works", function() {
+				assert.equal(JSON.stringify(result[0]), '{"State":"Testing","id":"ExampleId"}');
 			});
 		});
 
-		it("listing instances without a name tag works", function() {
-			assert.equal(JSON.stringify(result[0]), 
-							'{"State":"Testing","id":"ExampleId"}');
+		describe("getInstancesStopped", function() {
+			before(function() {
+				spy = sinon.spy(ecInstance, 'getInstancesStatus');
+				return ecInstance.getInstancesStopped('tag', 'My-EC2', auth1);
+			});
+
+			after(function() {
+				ecInstance.getInstancesStatus.restore();
+			});
+
+			it("getting data about stopped instances works", function() {
+				assert.equal(spy.calledWith('tag', 'My-EC2', 'stopped', auth1), true);
+			});
+		});
+
+		describe("getInstancesStarted", function() {
+			before(function() {
+				spy = sinon.spy(ecInstance, 'getInstancesStatus');
+				return ecInstance.getInstancesStarted('tag', 'My-EC2', auth1);
+			});
+
+			it("getting data about started instances works", function() {
+				assert.equal(spy.calledWith('tag', 'My-EC2', 'running', auth1), true);
+			});
 		});
 	});
 
-	describe("getInstancesStatus", function() {
-		before(function() {
-			return ecInstance.getInstancesStatus('tag', 'My-EC2', 'running', auth1)
-			.then(function(data) {
-				result = data;
+	describe("Retrieving EC2 Logs", function() {
+		describe("getLogs", function() {
+			before(function() {
+				AWS.ec2.restore();
+				sinon.stub(AWS, 'ec2', function(auth) {
+					this.getConsoleOutputPromised = function(params) {
+						return Promise.resolve({Timestamp : 1, Output : 'dGVzdA=='});
+					};
+					this.describeInstancesPromised = function(params) {
+						var data = {};
+						data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
+												Tags : [{Key : 'NotName', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
+						return Promise.resolve(data);
+					};
+				});
+				return ecInstance.getLogs('tag', 'My-EC2', auth1)
+				.then(function(data) {
+					result = data;
+				});
+			});
+
+			it("getting logs about an instance works", function() {
+				assert.equal(result, 'Timestamp: 1\ntest');
 			});
 		});
 
-		it("getting data about instances based on state works", function() {
-			assert.equal(JSON.stringify(result[0]), '{"State":"Testing","id":"ExampleId"}');
-		});
-	});
+		describe("getLogs with multiple instances", function() {
+			before(function() {
+				AWS.ec2.restore();
+				sinon.stub(AWS, 'ec2', function(auth) {
+					this.describeInstancesPromised = function(params) {
+						var data = {};
+						data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
+															Tags : [{Key : 'NotName', Value : 'Tag'}], State : {Name : 'Testing'}},
+															{InstanceId : 'OtherId', 
+																Tags : [{Key : 'OtherName', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
+						return Promise.resolve(data);
+					};
+				});
+				return ecInstance.getLogs('tag', 'My-EC2', auth1)
+				.catch(function(err) {
+					result = err;
+				});
+			});
 
-	describe("getInstancesStopped", function() {
-		before(function() {
-			spy = sinon.spy(ecInstance, 'getInstancesStatus');
-			return ecInstance.getInstancesStopped('tag', 'My-EC2', auth1);
-		});
-
-		after(function() {
-			ecInstance.getInstancesStatus.restore();
-		});
-
-		it("getting data about stopped instances works", function() {
-			assert.equal(spy.calledWith('tag', 'My-EC2', 'stopped', auth1), true);
-		});
-	});
-
-	describe("getInstancesStarted", function() {
-		before(function() {
-			spy = sinon.spy(ecInstance, 'getInstancesStatus');
-			return ecInstance.getInstancesStarted('tag', 'My-EC2', auth1);
-		});
-
-		it("getting data about started instances works", function() {
-			assert.equal(spy.calledWith('tag', 'My-EC2', 'running', auth1), true);
-		});
-	});
-
-	describe("getLogs", function() {
-		before(function() {
-			return ecInstance.getLogs('tag', 'My-EC2', auth1)
-			.then(function(data) {
-				result = data;
+			it("does not retrieve logs if more than one instance is specified", function() {
+				assert.equal(result, 'More than one instance specified.');
 			});
 		});
 
-		it("getting logs about an instance works", function() {
-			assert.equal(result, 'Timestamp: 1\ntest');
-		});
-	});
-
-	describe("getLogs with multiple instances", function() {
-		before(function() {
-			AWSMock.restore('EC2', 'describeInstances');
-			AWSMock.mock('EC2', 'describeInstances', function(params, callback) {
-				var data = {};
-				data.Reservations = [{Instances : [{InstanceId : 'ExampleId', 
-													Tags : [{Key : 'NotName', Value : 'Tag'}], State : {Name : 'Testing'}},
-													{InstanceId : 'OtherId', 
-														Tags : [{Key : 'OtherName', Value : 'Tag'}], State : {Name : 'Testing'}}]}];
-				callback(null, data);
+		describe("getLogs with no instances", function() {
+			before(function() {
+				AWS.ec2.restore();
+				sinon.stub(AWS, 'ec2', function(auth) {
+					this.describeInstancesPromised = function(params) {
+						return Promise.resolve({});
+					};
+				});
+				return ecInstance.getLogs('tag', 'My-EC2', auth1)
+				.catch(function(err) {
+					result = err;
+				});
 			});
-			return ecInstance.getLogs('tag', 'My-EC2', auth1)
-			.catch(function(err) {
-				result = err;
-			});
-		});
 
-		it("does not retrieve logs if more than one instance is specified", function() {
-			assert.equal(result, 'More than one instance specified.');
-		});
-	});
-
-	describe("getLogs with no instances", function() {
-		before(function() {
-			AWSMock.restore('EC2', 'describeInstances');
-			AWSMock.mock('EC2', 'describeInstances', function(params, callback) {
-				callback(null, {});
+			it("does not retrieve logs if no instances are specified", function() {
+				assert.equal(result, 'No instances available.');
 			});
-			return ecInstance.getLogs('tag', 'My-EC2', auth1)
-			.catch(function(err) {
-				result = err;
-			});
-		});
-
-		it("does not retrieve logs if no instances are specified", function() {
-			assert.equal(result, 'No instances available.');
 		});
 	});
 
 	describe("reboot", function() {
 		before(function() {
+			AWS.ec2.restore();
+			sinon.stub(AWS, 'ec2', function(auth) {
+				this.startInstancesPromised = function(params) {
+					return Promise.resolve(true);
+				};
+				this.stopInstancesPromised = function(params) {
+					return Promise.resolve(true);
+				};
+				this.describeInstancesPromised = function(params) {
+					return Promise.resolve({});
+				};
+				this.waitForPromised = function(params) {
+					return Promise.resolve("Success");
+				};
+			});
 			return ecInstance.reboot('tag', 'My-EC2', auth1)
 			.then(function(data) {
 				result = data;

--- a/test/test-auth.js
+++ b/test/test-auth.js
@@ -2,124 +2,66 @@ var assert = require('chai').assert;
 var opkit = require('../index');
 
 describe('Auth', function() {
+
+	var auth1;
+
+	afterEach(function() {
+		auth1 = undefined;
+	});
+
 	describe('#updateRegion()', function () {
-		it('should update the region in that particular object', function () {
-			var auth1 = new opkit.Auth();
+		before(function() {
+			auth1 = new opkit.Auth();
 			auth1.updateRegion("us-east-1");
-			assert.equal("us-east-1", auth1.props.region);
-			auth1.updateRegion("hell");
-			assert.equal("hell", auth1.props.region);
 		});
 
-		it('should update the region in that particular object,\n' +
-		'and not change the region in other auth objects', function () {
-			var auth1 = new opkit.Auth();
-			var auth2 = new opkit.Auth();
-			auth1.updateRegion("us-east-1");
-			auth2.updateRegion("us-east-1");
+		it('should update the region in that particular object', function () {
 			assert.equal("us-east-1", auth1.props.region);
-			assert.equal("us-east-1", auth2.props.region);
-			auth2.updateRegion("hell");
-			assert.equal("us-east-1", auth1.props.region);
-			assert.equal("hell", auth2.props.region);
 		});
 	});
 
 	describe('#updateAuthKeys()', function () {
-		it('should update the keys in that particular object', function () {
-			var auth1 = new opkit.Auth();
+		before(function() {
+			auth1 = new opkit.Auth();
 			auth1.updateAuthKeys("skeleton", "other_skeleton");
-			assert.equal("skeleton", auth1.props.accessKeyId);
-			assert.equal("other_skeleton", auth1.props.secretAccessKey);
-			auth1.updateAuthKeys("third_skeleton", "broken_shard_of_glass");
-			assert.equal("third_skeleton", auth1.props.accessKeyId);
-			assert.equal("broken_shard_of_glass", auth1.props.secretAccessKey);
 		});
 
-		it('should update the keys in that particular object,\n' +
-		'and not change the keys in other auth objects', function () {
-			var auth1 = new opkit.Auth();
-			var auth2 = new opkit.Auth();
-			auth1.updateAuthKeys("skeleton", "other_skeleton");
-			auth2.updateAuthKeys("skeleton", "other_skeleton");
+		it('should update the keys in that particular object', function () {
 			assert.equal("skeleton", auth1.props.accessKeyId);
 			assert.equal("other_skeleton", auth1.props.secretAccessKey);
-			assert.equal("skeleton", auth2.props.accessKeyId);
-			assert.equal("other_skeleton", auth2.props.secretAccessKey);
-			auth2.updateAuthKeys("third_skeleton", "broken_shard_of_glass");
-			assert.equal("skeleton", auth1.props.accessKeyId);
-			assert.equal("other_skeleton", auth1.props.secretAccessKey);
-			assert.equal("third_skeleton", auth2.props.accessKeyId);
-			assert.equal("broken_shard_of_glass", auth2.props.secretAccessKey);
 		});
 	});
 
 	describe('#updateAccessKeyId()', function () {
-		it('should update the access key ID', function () {
-			var auth1 = new opkit.Auth();
+		before(function() {
+			auth1 = new opkit.Auth();
 			auth1.updateAccessKeyId("skeleton");
-			assert.equal("skeleton", auth1.props.accessKeyId);
-			auth1.updateAccessKeyId("well_fed_key");
-			assert.equal("well_fed_key", auth1.props.accessKeyId);
 		});
 
-		it('should update the access key ID in that particular object,\n' +
-		'and not change other keys', function () {
-			var auth1 = new opkit.Auth();
-			var auth2 = new opkit.Auth();
-			auth1.updateAccessKeyId("skeleton");
-			auth2.updateAccessKeyId("skeleton");
+		it('should update the access key ID', function () {
 			assert.equal("skeleton", auth1.props.accessKeyId);
-			assert.equal("skeleton", auth2.props.accessKeyId);
-			auth2.updateAccessKeyId("well_fed_key");
-			assert.equal("skeleton", auth1.props.accessKeyId);
-			assert.equal("well_fed_key", auth2.props.accessKeyId);
 		});
 	});
 
 	describe('#updateSecretAccessKey()', function () {
-		it('should update the secret access key in that particular object', function () {
-			var auth1 = new opkit.Auth();
+		before(function() {
+			auth1 = new opkit.Auth();
 			auth1.updateSecretAccessKey("skeleton");
-			assert.equal("skeleton", auth1.props.secretAccessKey);
-			auth1.updateSecretAccessKey("lockpick");
-			assert.equal("lockpick", auth1.props.secretAccessKey);
 		});
 
-		it('should update the secret access key in that particular object,\n' +
-		'and not change other keys', function () {
-			var auth1 = new opkit.Auth();
-			var auth2 = new opkit.Auth();
-			auth1.updateSecretAccessKey("skeleton");
-			auth2.updateSecretAccessKey("skeleton");
+		it('should update the secret access key in that particular object', function () {
 			assert.equal("skeleton", auth1.props.secretAccessKey);
-			assert.equal("skeleton", auth2.props.secretAccessKey);
-			auth2.updateSecretAccessKey("lockpick");
-			assert.equal("skeleton", auth1.props.secretAccessKey);
-			assert.equal("lockpick", auth2.props.secretAccessKey);
 		});
 	});
 
 	describe('#updateShortName', function () {
-		it('should update the short name in that particular object', function () {
-			var auth1 = new opkit.Auth();
+		before(function() {
+			auth1 = new opkit.Auth();
 			auth1.updateShortName("skeleton");
-			assert.equal("skeleton", auth1.shortName);
-			auth1.updateShortName("lockpick");
-			assert.equal("lockpick", auth1.shortName);
 		});
 
-		it('should update the short name in that particular object,\n' +
-		'and not change other names', function () {
-			var auth1 = new opkit.Auth();
-			var auth2 = new opkit.Auth();
-			auth1.updateShortName("skeleton");
-			auth2.updateShortName("skeleton");
+		it('should update the short name in that particular object', function () {
 			assert.equal("skeleton", auth1.shortName);
-			assert.equal("skeleton", auth2.shortName);
-			auth2.updateShortName("lockpick");
-			assert.equal("skeleton", auth1.shortName);
-			assert.equal("lockpick", auth2.shortName);
 		});
 	});
 });

--- a/test/test-bot.js
+++ b/test/test-bot.js
@@ -5,81 +5,88 @@ var Promise = require('bluebird');
 var _ = require('lodash');
 require('sinon-as-promised')(Promise);
 
-var pattern = function(message, bot, auths){
-	return (message.text === 'boogie');
-};
-var logic = function(message, bot, auths){
-	bot.sendMessage('You know I can boogie down', message.channel);
-	if (message.user === 'user') {
-		bot.sendMessage('Specially for you', message.channel);		
-	} else {
-		return Promise.reject();	
-	} 
-	return Promise.resolve();
-};
-
-var otherPattern = function(message, bot, auths){
-	return (message.text === 'opkit twelve');
-};
-var otherLogic = function(message, bot, auths){
-	bot.sendMessage('Twelve, from the special handler', message.channel);
-	if (message.user === 'user') {
-		return Promise.resolve();
-	} else {
-		return Promise.reject();	
-	} 
-};
-
-var sendsTwelve = function(message, bot, auth){
-	bot.sendMessage('12', message.channel);
-	return Promise.resolve("Bot successfully sent the string literal '12'.");
-};
-
-var authorizationFunction = function(message, bot, auth){
-	return Promise.resolve(['A', 'B', 'C']);
-};
-
-var sendsTwelveObject = {
-	command : sendsTwelve,
-	name : 'twelve',
-	syntax : [	['give', 'me', 'twelve'],
-				['send', 'me', 'twelve'],
-				['send', 'twelve'],
-				['give', 'me', 'a', 'number'],
-				'twelve'],
-	package : 'numbers'
-}
-
-var otherObject = {
-	command : sendsTwelve,
-	name : 'totesnotTwelve',
-	syntax : ['give', 'me', 'totesnotTwelve'],
-	package : 'numbers'
-}
-
-var mockPersister = {
-	save : function(brain, package){
-		return Promise.resolve(true);
-	},
-	recover : function(package){
-		return Promise.resolve({
-			data : 'some_data'
-		});
-	},
-	start : function(){
-		return Promise.resolve(true);
-	}
-}
-
-var failsToSendTwelve = function(message, bot, auth){
-	return Promise.reject("Bot couldn't send '12' for some reason.");
-};
-
-var bot;
-
-var clock = sinon.useFakeTimers();
-
 describe('Bot', function(){
+
+	var pattern = function(message, bot, auths){
+		return (message.text === 'boogie');
+	};
+
+	var logic = function(message, bot, auths){
+		bot.sendMessage('You know I can boogie down', message.channel);
+		if (message.user === 'user') {
+			bot.sendMessage('Specially for you', message.channel);		
+		} else {
+			return Promise.reject();	
+		} 
+		return Promise.resolve();
+	};
+
+	var otherPattern = function(message, bot, auths){
+		return (message.text === 'opkit twelve');
+	};
+	var otherLogic = function(message, bot, auths){
+		bot.sendMessage('Twelve, from the special handler', message.channel);
+		if (message.user === 'user') {
+			return Promise.resolve();
+		} else {
+			return Promise.reject();	
+		} 
+	};
+
+	var sendsTwelve = function(message, bot, auth){
+		bot.sendMessage('12', message.channel);
+		return Promise.resolve("Bot successfully sent the string literal '12'.");
+	};
+
+	var authorizationFunction = function(message, bot, auth){
+		return Promise.resolve(['A', 'B', 'C']);
+	};
+
+	var sendsTwelveObject = {
+		command : sendsTwelve,
+		name : 'twelve',
+		syntax : [	['give', 'me', 'twelve'],
+					['send', 'me', 'twelve'],
+					['send', 'twelve'],
+					['give', 'me', 'a', 'number'],
+					'twelve'],
+		package : 'numbers'
+	};
+
+	var otherObject = {
+		command : sendsTwelve,
+		name : 'totesnotTwelve',
+		syntax : ['give', 'me', 'totesnotTwelve'],
+		package : 'numbers'
+	};
+
+	var mockPersister = {
+		save : function(brain, package){
+			return Promise.resolve(true);
+		},
+		recover : function(package){
+			return Promise.resolve({
+				data : 'some_data'
+			});
+		},
+		start : function(){
+			return Promise.resolve(true);
+		}
+	};
+
+	var failsToSendTwelve = function(message, bot, auth){
+		return Promise.reject("Bot couldn't send '12' for some reason.");
+	};
+
+	var bot;
+	var result;
+
+	var clock = sinon.useFakeTimers();
+
+	afterEach(function() {
+		result = undefined;
+	});
+
 	describe('#Constructor without params', function(){
 		before(function(){
 			bot = new Opkit.Bot(
@@ -270,7 +277,6 @@ describe('Bot', function(){
 			);	
 		});
 		describe('#case of match without params', function () {
-			var result;
 			before(function(){
 				return bot.messageParser(['testbot', 'send', 'me', 'twelve'], bot)
 				.then(function(data){
@@ -283,8 +289,6 @@ describe('Bot', function(){
 			});
 		});
 		describe('#case of match with params', function () {
-			var result;
-
 			before(function(){
 				return bot.messageParser(['testbot', 'send', 'me', 'twelve' ,'please'], bot)
 				.then(function(data){
@@ -294,15 +298,10 @@ describe('Bot', function(){
 
 			it('should return a match', function(){
 				assert.equal(result.command, sendsTwelveObject);
-			});
-
-			it('should return the correct args', function(){
 				assert.deepEqual(result.args, ['please']);
 			});
 		});
 		describe('#case with no match (JW distance high; likely typo)', function(){
-			var result;
-			
 			before(function(){
 				return bot.messageParser(['testbot', 'send', 'me', 'twilve'], bot)
 				.then(function(){
@@ -318,8 +317,6 @@ describe('Bot', function(){
 			});
 		});
 		describe('#case with no match (JW distance low; unlikely typo)', function(){
-			var result;
-			
 			before(function(){
 				return bot.messageParser(['testbot', 'fdasfdsfsdaf', 'fdsfdsdf', 'fdafdfdfdfdfdfdfdfdfdfdfd'], bot)
 				.then(function(){
@@ -461,7 +458,6 @@ describe('Bot', function(){
 			);
 		});
 		describe('#case where a user has one role', function(){
-			var result;
 			before(function(){
 				bot.messageParser = sinon.mock().resolves({
 					command : sendsTwelveObject,
@@ -483,7 +479,6 @@ describe('Bot', function(){
 			});
 		});
 		describe('#case where a user has multiple roles', function(){
-			var result;
 			before(function(){
 				bot.messageParser = sinon.mock().resolves({
 					command : sendsTwelveObject,
@@ -508,7 +503,6 @@ describe('Bot', function(){
 			});
 		});
 		describe('#case where access is denied', function(){
-			var result;
 			before(function(){
 				bot.messageParser = sinon.mock().resolves({
 					command : sendsTwelveObject,
@@ -533,7 +527,6 @@ describe('Bot', function(){
 			});
 		});
 		describe("#case where the command rejects promise", function(){
-			var result;
 			before(function(){
 				bot.messageParser = sinon.mock().resolves({
 					command : sendsTwelveObject,
@@ -557,7 +550,7 @@ describe('Bot', function(){
 			});
 			it('should still resolve', function(){
 				assert(result);							
-			})
+			});
 		}); 
 	});
 });


### PR DESCRIPTION
This PR cleans up some tests that were written awhile ago. The tests are now mocked directly using sinon instead of the aws-sdk-mock package for improved consistency, readability and quality of the tests.

Thank you for your feedback.
