### PR TITLE
Alarms Bugfix

### DIFF
--- a/lib/alarms.js
+++ b/lib/alarms.js
@@ -27,11 +27,13 @@ Alarms.prototype.getAllAlarms = function(auth, params, ignore, prevResults){
 			return self.getAllAlarms(auth, params, ignore, data);
 		} else {
 			if (ignore) {
+				var nonIgnoredAlarms = [];
 				for (var alarmIdx = 0; alarmIdx < data.MetricAlarms.length; alarmIdx++) {
-					if(_.includes(ignore, data.MetricAlarms[alarmIdx].AlarmName)) {
-						data.MetricAlarms.splice(alarmIdx, 1);
+					if(!(_.includes(ignore, data.MetricAlarms[alarmIdx].AlarmName))) {
+						nonIgnoredAlarms.push(data.MetricAlarms[alarmIdx]);
 					}
 				}
+				data.MetricAlarms = nonIgnoredAlarms;
 			}
 			return Promise.resolve(data);
 		}


### PR DESCRIPTION
Fixing a bug -- though this code has not caused any problems, it has the potential to. Previously, we were iterating through an array and using the 'splice' method to remove alarms which should not have been in the list (the ones specified by the ignore param). Since the array is being mutated as it is being iterated over, there is potential for some alarms to be skipped over.

The new implementation creates a new array and pushes all the alarms which are not on the ignore list onto it, and then returns the new array as a field in the data.

Thank you for your feedback.
