### PR TITLE
Slack token can now be specified in bot constructor

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -51,11 +51,12 @@ function OpkitBot(name, cmds, persister, params) {
 	this.handlers = [];
 	this.oneoffHandlers = [];
 	this.logLevel = params.logLevel || 'PROD';
+	this.token = params.token || process.env.token;
 	this.dataStore = new MemoryDataStore();
 	if (this.logLevel === 'DEBUG'){
-		this.rtm = new RtmClient(process.env.token, {dataStore : self.dataStore, logLevel : 'debug'});
+		this.rtm = new RtmClient(this.token, {dataStore : self.dataStore, logLevel : 'debug'});
 	} else {
-		this.rtm = new RtmClient(process.env.token, {dataStore : self.dataStore});		
+		this.rtm = new RtmClient(this.token, {dataStore : self.dataStore});		
 	}
 	if (this.logLevel === 'TEST'){
 		winston.log = function () {};


### PR DESCRIPTION
Previously, slack token was taken as an environment variable. Now, the parameter can be passed in to the bot constructor. This simplifies running multiple bots on one Heroku dyno. This is a nonbreaking change, as tokens passed in through environment variable will still work.
