### PR TITLE
Removed default values for token and loglevel

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -50,8 +50,8 @@ function OpkitBot(name, cmds, persister, params) {
 	// This initializes two arrays we're using to hold event handlers.
 	this.handlers = [];
 	this.oneoffHandlers = [];
-	this.logLevel = params.logLevel || 'PROD';
-	this.token = params.token || process.env.token;
+	this.logLevel = params.logLevel;
+	this.token = params.token;
 	this.dataStore = new MemoryDataStore();
 	if (this.logLevel === 'DEBUG'){
 		this.rtm = new RtmClient(this.token, {dataStore : self.dataStore, logLevel : 'debug'});


### PR DESCRIPTION
Pulling random environment variables with names like "token" as default is probably worse than just having people specify it in the constructor.